### PR TITLE
Add CLI, fix bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,35 @@ makeIncremental(
     }
 );
 ```
+
+## CLI
+
+Install this package globally:
+
+```
+npm i -g babylonjs-make-incremental
+```
+
+Run the command:
+
+```
+babylonjs-make-incremental --src=./src/scenes/mainScene  --excludedMeshes="^car-,^box-,^building"
+```
+
+The `excludedMeshes` option should be a string of comma-delimited regexp strings, each of which will be passed to the constructor `new RegExp()`.
+
+## Developing this project
+
+Clone the repo, then do the usual setup:
+
+```
+$ npm install && npm run build
+```
+
+To develop the CLI, you need to run:
+
+```
+$ npm link
+```
+
+This should symlink the CLI and make it possible to call directly.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,7 +9,6 @@ const incrementalPart = ".incremental";
 
 export interface OptionProps {
     excludedMeshes?: RegExp[];
-    skipFixSeparators?: boolean;
 }
 
 interface SearchOptionsProps {
@@ -21,9 +20,7 @@ export function makeIncremental(src: string, options: OptionProps = {}) {
         throw new Error("No source directory provided. Please pass src in the options, e.g. /scene");
     }
 
-    const parsedSrc = (options.skipFixSeparators)
-        ? src
-        : fixSeparators(src);
+    const parsedSrc = fixSeparators(src);
 
     const parsedOptions = {
         excludedMeshes: (options.excludedMeshes || []),

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,6 +6,7 @@ import { readdirSync, readFileSync, writeFileSync } from "fs";
 
 export interface OptionProps {
     excludedMeshes?: RegExp[];
+    skipFixSeparators?: boolean;
 }
 
 interface SearchOptionsProps {
@@ -17,7 +18,9 @@ export default function makeIncremental(src: string, options: OptionProps = {}) 
         throw new Error("No source directory provided. Please pass src in the options, e.g. /scene");
     }
 
-    const parsedSrc = fixSeparators(src);
+    const parsedSrc = (options.skipFixSeparators)
+        ? src
+        : fixSeparators(src);
 
     const parsedOptions = {
         excludedMeshes: (options.excludedMeshes || []),

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,9 @@
 import { join, sep } from "path";
 import { readdirSync, readFileSync, writeFileSync } from "fs";
 
+const babylonExtension = ".babylon";
+const incrementalPart = ".incremental";
+
 export interface OptionProps {
     excludedMeshes?: RegExp[];
     skipFixSeparators?: boolean;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -33,6 +33,12 @@ function searchBabylonFiles(root: string, currentPath: string, options: SearchOp
     readdirSync(currentPath).forEach((file: string) => {
         const filePath = join(currentPath, file);
         const babylonExtension = ".babylon";
+        const incrementalPart = ".incremental";
+
+        // Skip incremental files that already exist
+        if (file.indexOf(incrementalPart) !== -1) {
+            return;
+        }
 
         if (file.indexOf(babylonExtension) > 0
             && file.indexOf(babylonExtension) === file.length - babylonExtension.length
@@ -72,7 +78,7 @@ function searchBabylonFiles(root: string, currentPath: string, options: SearchOp
             }
 
             // Saving
-            const outputPath = `${filename}.incremental.babylon`;
+            const outputPath = `${filename}${incrementalPart}babylon`;
             const json = JSON.stringify(scene, null, 0);
             writeFileSync(join(currentPath, outputPath), json);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -182,6 +182,11 @@
         "brace-expansion": "1.1.8"
       }
     },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "babel-code-frame": {
@@ -37,9 +37,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "chalk": {
@@ -48,11 +48,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         }
       }
@@ -69,7 +69,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -85,9 +85,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.5.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -96,7 +96,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.3"
           }
         },
         "supports-color": {
@@ -105,7 +105,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -149,7 +149,7 @@
       "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
       "dev": true,
       "requires": {
-        "esutils": "^1.1.6",
+        "esutils": "1.1.6",
         "isarray": "0.0.1"
       },
       "dependencies": {
@@ -191,12 +191,12 @@
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "has-ansi": {
@@ -205,7 +205,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-flag": {
@@ -220,8 +220,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -248,8 +248,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "minimatch": {
@@ -258,7 +258,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -272,7 +272,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "path-is-absolute": {
@@ -293,7 +293,7 @@
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.6"
       }
     },
     "semver": {
@@ -310,11 +310,11 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "supports-color": {
@@ -335,18 +335,18 @@
       "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^3.2.0",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.8.0",
-        "tsutils": "^2.27.2"
+        "babel-code-frame": "6.26.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.4.1",
+        "commander": "2.19.0",
+        "diff": "3.5.0",
+        "glob": "7.1.3",
+        "js-yaml": "3.12.0",
+        "minimatch": "3.0.4",
+        "resolve": "1.8.1",
+        "semver": "5.6.0",
+        "tslib": "1.9.3",
+        "tsutils": "2.29.0"
       }
     },
     "tslint-eslint-rules": {
@@ -357,7 +357,7 @@
       "requires": {
         "doctrine": "0.7.2",
         "tslib": "1.9.0",
-        "tsutils": "^3.0.0"
+        "tsutils": "3.3.1"
       },
       "dependencies": {
         "tslib": {
@@ -372,7 +372,7 @@
           "integrity": "sha512-reuFQ3/EoMy70YvBPrxe9p7LvA4dCQnvMn+LV8Tv2NKkLCKRHgfB4qFTA9NtWlyYSldTu1dukuquQ3o0mLvsPw==",
           "dev": true,
           "requires": {
-            "tslib": "^1.8.1"
+            "tslib": "1.9.0"
           }
         }
       }
@@ -383,7 +383,7 @@
       "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
       "dev": true,
       "requires": {
-        "tslib": "^1.8.1"
+        "tslib": "1.9.3"
       }
     },
     "typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "babylonjs-make-incremental",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "A tool that generates incremental files from a babylon file.",
   "main": "index.js",
   "types": "index.d.ts",
+  "bin": {
+    "babylonjs-make-incremental": "./cli.js"
+  },
   "scripts": {
     "build": "npm run lint && node ./node_modules/typescript/lib/tsc.js",
     "lint": "node ./node_modules/tslint/bin/tslint './lib/*.ts' --type-check -p .",
@@ -23,5 +26,8 @@
     "tslint": "^5.5.0",
     "tslint-eslint-rules": "3.4.0",
     "typescript": "^2.4.1"
+  },
+  "dependencies": {
+    "minimist": "^1.2.0"
   }
 }


### PR DESCRIPTION
1. Adds a standard Node.js CLI for this module (see README for usage).
2. Fixes a bug where files that were already `*.incremental.*` files were processed again and again, leading to ever-multiplying files being produced on each run.

Note: The `fixSeparators` call was interfering with expectations for the CLI so I added an option to disable that behavior that is only used in the CLI code path. It should not interfere with normal usage.